### PR TITLE
Add parametric workflow to generate community bundle

### DIFF
--- a/.github/workflows/release_community_bundle_parametric.yaml
+++ b/.github/workflows/release_community_bundle_parametric.yaml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       community:
-        description: "The community to release the bundle to (either `k8s-operatorhub` or `redhat-openshift-ecosystem`)"
+        description: "The community to release the bundle to (either `K8S` or `OKD`)"
         required: true
         type: string
       recipe:
@@ -60,7 +60,7 @@ jobs:
 
       - name: Checkout Kubernetes Community Operators Hub
         uses: actions/checkout@v3
-        if: ${{ inputs.community == 'k8s-operatorhub' }}
+        if: ${{ inputs.community == 'K8S' }}
         with:
           repository: 'k8s-operatorhub/community-operators'
           path: community
@@ -69,7 +69,7 @@ jobs:
 
       - name: Checkout Red Hat Community Operators
         uses: actions/checkout@v3
-        if: ${{ inputs.community == 'redhat-openshift-ecosystem' }}
+        if: ${{ inputs.community == 'OKD' }}
         with:
           repository: 'redhat-openshift-ecosystem/community-operators-prod'
           path: community
@@ -91,9 +91,9 @@ jobs:
 
       - name: Commit and push
         run: |
-          if [ ${{ inputs.community }} == 'k8s-operatorhub' ]; then
+          if [ ${{ inputs.community }} == 'K8S' ]; then
             git -C community remote add fork https://github.com/medik8s/community-operators.git
-          elif [ ${{ inputs.community }} == 'redhat-openshift-ecosystem' ]; then
+          elif [ ${{ inputs.community }} == 'OKD' ]; then
             git -C community remote add fork https://github.com/medik8s/community-operators-prod.git
           else
             echo "Unknown community: ${{ inputs.community }}"

--- a/.github/workflows/release_community_bundle_parametric.yaml
+++ b/.github/workflows/release_community_bundle_parametric.yaml
@@ -21,8 +21,8 @@ on:
         description: "The community to release the bundle to (either `K8S` or `OKD`)"
         required: true
         type: string
-      recipe:
-        description: "The recipe to use for creating the community bundle"
+      make_targets:
+        description: "The Makefile targets to use for creating the community bundle"
         required: true
         type: string
 
@@ -42,7 +42,7 @@ jobs:
       - name: Log inputs
         run: |
           echo "Community: ${{ inputs.community }}"
-          echo "Recipe: ${{ inputs.recipe }}"
+          echo "Make targets: ${{ inputs.make_targets }}"
           echo "Building version: ${VERSION}"
           echo "which replaces version: ${PREVIOUS_VERSION}"
           echo "Lower skip range bound: ${SKIP_RANGE_LOWER}"
@@ -81,7 +81,7 @@ jobs:
           export VERSION=${VERSION} 
           export PREVIOUS_VERSION=${PREVIOUS_VERSION}
           export SKIP_RANGE_LOWER=${SKIP_RANGE_LOWER}
-          rm -r operator/bundle && make -C operator ${{ inputs.recipe }}
+          rm -r operator/bundle && make -C operator ${{ inputs.make_targets }}
 
       - name: Copy bundle
         run: |

--- a/.github/workflows/release_community_bundle_parametric.yaml
+++ b/.github/workflows/release_community_bundle_parametric.yaml
@@ -106,5 +106,5 @@ jobs:
           git -C community add operators/${OPERATOR_NAME}/${VERSION}
           git -C community switch --create ${BRANCH}
           git -C community status
-          git -C community commit -m "Add ${OPERATOR_NAME}-${VERSION}"
+          git -C community commit --signoff --message "Add ${OPERATOR_NAME}-${VERSION}"
           git -C community push --set-upstream fork ${BRANCH}

--- a/.github/workflows/release_community_bundle_parametric.yaml
+++ b/.github/workflows/release_community_bundle_parametric.yaml
@@ -1,0 +1,110 @@
+name: Community bundle
+on:
+  workflow_call:
+    secrets:
+      COMMUNITY_OPERATOR_TOKEN:
+        required: true
+    inputs:
+      version:
+        description: "The version to release, without the leading `v`"
+        required: true
+        type: string
+      previous_version:
+        description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
+        required: true
+        type: string
+      skip_range_lower:
+        description: "Lower bound for the skipRange field in the CSV, should be set to the oldest supported version, without the leading `v`"
+        required: true
+        type: string
+      community:
+        description: "The community to release the bundle to (either `k8s-operatorhub` or `redhat-openshift-ecosystem`)"
+        required: true
+        type: string
+      recipe:
+        description: "The recipe to use for creating the community bundle"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  make_community_bundle:
+    name: Build and commit PR for bundle in Operator Community
+    runs-on: ubuntu-22.04
+    env:
+      PROJECT: ${{ github.repository }}
+      VERSION: ${{ inputs.version }}
+      PREVIOUS_VERSION: ${{ inputs.previous_version }}
+      SKIP_RANGE_LOWER: ${{ inputs.skip_range_lower }}
+    steps:
+      - name: Log inputs
+        run: |
+          echo "Community: ${{ inputs.community }}"
+          echo "Recipe: ${{ inputs.recipe }}"
+          echo "Building version: ${VERSION}"
+          echo "which replaces version: ${PREVIOUS_VERSION}"
+          echo "Lower skip range bound: ${SKIP_RANGE_LOWER}"
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: operator
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: operator/go.mod
+
+      - name: Checkout Kubernetes Community Operators Hub
+        uses: actions/checkout@v3
+        if: ${{ inputs.community == 'k8s-operatorhub' }}
+        with:
+          repository: 'k8s-operatorhub/community-operators'
+          path: community
+          token: ${{ secrets.COMMUNITY_OPERATOR_TOKEN }}
+          fetch-depth: 0
+
+      - name: Checkout Red Hat Community Operators
+        uses: actions/checkout@v3
+        if: ${{ inputs.community == 'redhat-openshift-ecosystem' }}
+        with:
+          repository: 'redhat-openshift-ecosystem/community-operators-prod'
+          path: community
+          token: ${{ secrets.COMMUNITY_OPERATOR_TOKEN }}
+          fetch-depth: 0
+
+      - name: Build Community bundle
+        run: |
+          export VERSION=${VERSION} 
+          export PREVIOUS_VERSION=${PREVIOUS_VERSION}
+          export SKIP_RANGE_LOWER=${SKIP_RANGE_LOWER}
+          rm -r operator/bundle && make -C operator ${{ inputs.recipe }}
+
+      - name: Copy bundle
+        run: |
+          OPERATOR_NAME=$(basename ${PROJECT})
+          mkdir -p community/operators/${OPERATOR_NAME}/${VERSION}
+          cp -vr operator/bundle/* community/operators/${OPERATOR_NAME}/${VERSION}
+
+      - name: Commit and push
+        run: |
+          if [ ${{ inputs.community }} == 'k8s-operatorhub' ]; then
+            git -C community remote add fork https://github.com/medik8s/community-operators.git
+          elif [ ${{ inputs.community }} == 'redhat-openshift-ecosystem' ]; then
+            git -C community remote add fork https://github.com/medik8s/community-operators-prod.git
+          else
+            echo "Unknown community: ${{ inputs.community }}"
+            exit 1
+          fi
+          OPERATOR_NAME=$(basename ${PROJECT})
+          BRANCH=add-${OPERATOR_NAME}-${VERSION}
+          git -C community config --global user.name "Medik8s Team"
+          git -C community config --global user.email "medik8s@googlegroups.com"
+          git -C community add operators/${OPERATOR_NAME}/${VERSION}
+          git -C community switch --create ${BRANCH}
+          git -C community status
+          git -C community commit -m "Add ${OPERATOR_NAME}-${VERSION}"
+          git -C community push --set-upstream fork ${BRANCH}


### PR DESCRIPTION

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### What this PR does / why we need it:
<!-- A clear description of the problem you are trying to solve -->

Add a reusable github workflow to automatically generate a bundle for RH or K8s Operator Hub and commit it to our Medik8s fork ready to be submitted to the Community project

Currently we have one workflow specific for RH Community, this new workflow reuses most of the same code to conditionally build and commit RH or K8s bundle based on parameters that the Operator's workflow must set in advance.

#### Test plan

I used https://github.com/nektos/act to reproduce the CI jobs locally

😁 