### PR TITLE
Replace COMMUNITY_OPERATOR_TOKEN PAT with GitHub App token

### DIFF
--- a/.github/workflows/release_community_bundle.yaml
+++ b/.github/workflows/release_community_bundle.yaml
@@ -2,7 +2,9 @@ name: Community bundle
 on:
   workflow_call:
     secrets:
-      COMMUNITY_OPERATOR_TOKEN:
+      RELEASE_APP_ID:
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
         required: true
     inputs:
       version:
@@ -80,13 +82,21 @@ jobs:
         with:
           go-version-file: operator/go.mod
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: medik8s
+
       - name: Checkout Kubernetes Community Operators Hub
         uses: actions/checkout@v6
         if: ${{ inputs.community == 'K8S' }}
         with:
           repository: 'k8s-operatorhub/community-operators'
           path: community
-          token: ${{ secrets.COMMUNITY_OPERATOR_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Checkout Red Hat Community Operators
@@ -95,7 +105,7 @@ jobs:
         with:
           repository: 'redhat-openshift-ecosystem/community-operators-prod'
           path: community
-          token: ${{ secrets.COMMUNITY_OPERATOR_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Build Community bundle


### PR DESCRIPTION
#### Why we need this PR

The community bundle workflow (`release_community_bundle.yaml`) was failing with
"Bad credentials" when checking out the community operator fork repositories
(`community-operators` and `community-operators-prod`). The `COMMUNITY_OPERATOR_TOKEN`
personal access token had expired.

Instead of replacing it with another PAT — which would expire again and is tied
to an individual account — this switches to a GitHub App-based authentication
flow. GitHub App installation tokens are short-lived (generated per workflow run),
not tied to any person, and don't expire as long as the app exists.

#### Changes made

- Replaced the `COMMUNITY_OPERATOR_TOKEN` secret with `RELEASE_APP_ID` and
  `RELEASE_APP_PRIVATE_KEY` secrets for the GitHub App
- Added a "Generate GitHub App token" step using `actions/create-github-app-token@v2`
  that creates a short-lived installation token scoped to the medik8s org
- Updated both community operators checkout steps (K8S and OKD) to use the
  generated app token instead of the PAT
- No changes needed in operator repos since they use `secrets: inherit`

**Prerequisites before merging:** (all done)
1. Create a GitHub App in the medik8s org (e.g. "medik8s-release-bot") with
   Contents read/write permission
2. Install the app on the medik8s org with access to `community-operators`,
   `community-operators-prod`, and all operator repos
3. Store the App ID and private key as org-level secrets `RELEASE_APP_ID` and
   `RELEASE_APP_PRIVATE_KEY`

#### Which issue(s) this PR fixes

Fixes the "Bad credentials" failure in all recent community release workflow runs
(e.g. https://github.com/medik8s/self-node-remediation/actions/runs/24127976048).

🤖 Generated with [Claude Code](https://claude.com/claude-code)