### PR TITLE
Fix OKD branch naming to include OCP version

### DIFF
--- a/.github/workflows/release_community_bundle.yaml
+++ b/.github/workflows/release_community_bundle.yaml
@@ -127,7 +127,11 @@ jobs:
         run: |
           OPERATOR_NAME="$(basename "${PROJECT}")"
           COMMUNITY_SUFFIX="$(echo "${{ inputs.community }}" | tr '[:upper:]' '[:lower:]')"
-          BRANCH="add-${OPERATOR_NAME}-${VERSION}-${COMMUNITY_SUFFIX}"
+          if [ "${{ inputs.community }}" == 'OKD' ] && [ -n "${OCP_VERSION}" ]; then
+            BRANCH="add-${OPERATOR_NAME}-${VERSION}-${COMMUNITY_SUFFIX}-${OCP_VERSION}"
+          else
+            BRANCH="add-${OPERATOR_NAME}-${VERSION}-${COMMUNITY_SUFFIX}"
+          fi
 
           if [ "${{ inputs.community }}" == 'K8S' ]; then
             git -C community remote add fork https://github.com/medik8s/community-operators.git


### PR DESCRIPTION
#### Why we need this PR

The community release workflow creates OKD branches without the OCP version
suffix (e.g. `add-self-node-remediation-0.11.1-okd`), but `community-release.sh`
expects branches with the OCP version included (e.g.
`add-self-node-remediation-0.11.1-okd-4.20`). This mismatch causes the script
to fail at the `create_prs` step:

```
WARNING: [SNR 0.11.1] OKD branch add-self-node-remediation-0.11.1-okd-4.20
does not exist on medik8s/community-operators-prod — cannot create PR
```

K8S branches are not affected since they don't include an OCP version.

#### Changes made

- Updated the "Commit and push" step in `release_community_bundle.yaml` to
  append `-${OCP_VERSION}` to the branch name when the community target is OKD
  and `ocp_version` is set
- K8S branch naming is unchanged

#### Which issue(s) this PR fixes

Fixes the OKD branch naming mismatch between the reusable workflow and
`community-release.sh`.

#### Test plan

- Run `community-release.sh --dry-run --step community` and verify the expected
  OKD branch names match the pattern `add-<operator>-<version>-okd-<ocp_version>`
- Trigger an OKD community release on one operator and verify the branch is
  created with the correct name and the PR step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)