### PR TITLE
Add NHC companion repo tagging and dry-run commit resolution

### DIFF
--- a/scripts/community-release.sh
+++ b/scripts/community-release.sh
@@ -21,6 +21,12 @@ declare -A OP_DISPLAY=()
 declare -A OP_QUAY_IMAGE=()
 declare -A OP_WORKFLOW=()
 
+# Companion repos: additional submodules that share the same downstream repo
+# and only need tagging on GitHub (no build/community/PR steps).
+declare -A OP_COMPANIONS=(
+    [NHC]="node-remediation-console must-gather"
+)
+
 DRY_RUN=false
 STEP=all          # tag, build, community, prs, or all
 CONFIG_FILE=""
@@ -345,69 +351,121 @@ tag_upstream() {
             info "[$op $version] Downstream tag: $downstream_tag (upstream: $tag)"
         fi
 
-        info "[$op $version] Checking tag $tag on medik8s/$repo"
-
-        if gh_tag_exists "medik8s/${repo}" "$tag"; then
-            info "[$op $version] Tag $tag already exists on medik8s/$repo — skipping tagging"
-            skipped+=("$op:$version")
-            continue
+        # Build list of repos to tag: main + companions
+        local -a tag_repos=("$repo")
+        local companions="${OP_COMPANIONS[$op]:-}"
+        if [[ -n "$companions" ]]; then
+            local -a comp_arr
+            read -ra comp_arr <<< "$companions"
+            tag_repos+=("${comp_arr[@]}")
         fi
 
-        local commit
-        commit=$(release_field "$i" commit)
-
-        if [[ -n "$commit" ]]; then
-            info "[$op $version] Using commit from config: $commit"
-        else
-            if [[ "$DRY_RUN" == true ]]; then
-                echo "[dry-run] Upstream tag $tag is missing from medik8s/$repo"
-                echo "[dry-run] Would clone downstream git@gitlab.cee.redhat.com:dragonfly/${repo}.git at tag $downstream_tag"
-                echo "[dry-run] Would extract submodule commit for '$repo'"
-                echo "[dry-run] Would clone upstream medik8s/$repo, create signed tag $tag, and push"
-                tagged+=("$op:$version")
+        # Check which repos still need a tag
+        local -a need_tag=()
+        for r in "${tag_repos[@]}"; do
+            info "[$op $version] Checking tag $tag on medik8s/$r"
+            if gh_tag_exists "medik8s/${r}" "$tag"; then
+                info "[$op $version] Tag $tag already exists on medik8s/$r — skipping tagging"
+                [[ "$r" != "$repo" ]] || skipped+=("$op:$version")
                 continue
             fi
+            need_tag+=("$r")
+        done
 
-            local tmp_downstream="/tmp/${repo}-tag-$$"
+        [[ ${#need_tag[@]} -gt 0 ]] || continue
 
+        # --- Resolve commits ---------------------------------------------------
+        # Config-level commit applies only to the main repo
+        local config_commit=""
+        config_commit=$(release_field "$i" commit)
+
+        # Determine if we need to clone downstream
+        local clone_needed=false
+        for r in "${need_tag[@]}"; do
+            if [[ "$r" == "$repo" && -n "$config_commit" ]]; then
+                continue   # main repo has config override
+            fi
+            clone_needed=true
+            break
+        done
+
+        local tmp_downstream=""
+        if [[ "$clone_needed" == true ]]; then
+            tmp_downstream="/tmp/${repo}-tag-$$"
             info "[$op $version] Cloning downstream at tag $downstream_tag"
             if ! git clone --depth 1 --branch "$downstream_tag" --no-checkout \
                 "git@gitlab.cee.redhat.com:dragonfly/${repo}.git" "$tmp_downstream" 2>/dev/null; then
                 rm -rf "$tmp_downstream"
                 die "Downstream tag $downstream_tag does not exist on dragonfly/${repo}. Create it as a prerequisite or set commit in the config."
             fi
+        fi
 
-            commit=$(git -C "$tmp_downstream" ls-tree HEAD "$repo" | awk '{print $3}')
-            rm -rf "$tmp_downstream"
-            if [[ -z "$commit" ]]; then
-                die "[$op $version] Could not extract submodule commit for '$repo' from downstream tag $downstream_tag"
+        # Resolve each repo's commit
+        # Using parallel arrays (bash associative arrays can't reliably be
+        # cleared inside a loop).
+        local -a resolved_repos=() resolved_commits=()
+        for r in "${need_tag[@]}"; do
+            local commit=""
+            if [[ "$r" == "$repo" && -n "$config_commit" ]]; then
+                commit="$config_commit"
+                info "[$op $version] Using commit from config: $commit"
+            else
+                commit=$(git -C "$tmp_downstream" ls-tree HEAD "$r" | awk '{print $3}')
+                if [[ -z "$commit" ]]; then
+                    rm -rf "$tmp_downstream"
+                    die "[$op $version] Could not extract submodule commit for '$r' from downstream tag $downstream_tag"
+                fi
+                info "[$op $version] Submodule commit for $r: $commit"
             fi
-            info "[$op $version] Submodule commit: $commit"
-        fi
+            resolved_repos+=("$r")
+            resolved_commits+=("$commit")
+        done
 
-        if [[ "$DRY_RUN" == true ]]; then
-            echo "[dry-run] Would create signed tag $tag on medik8s/$repo at commit $commit"
-            tagged+=("$op:$version")
-            continue
-        fi
+        [[ -z "$tmp_downstream" ]] || rm -rf "$tmp_downstream"
 
-        info "[$op $version] Creating signed tag $tag on medik8s/$repo at commit $commit"
-        local tmp_upstream="/tmp/${repo}-upstream-$$"
-        if ! gh repo clone "medik8s/${repo}" "$tmp_upstream" -- --depth 1 2>/dev/null; then
+        # --- Create tags -------------------------------------------------------
+        for idx in "${!resolved_repos[@]}"; do
+            local r="${resolved_repos[$idx]}"
+            local commit="${resolved_commits[$idx]}"
+
+            if [[ "$DRY_RUN" == true ]]; then
+                echo "[dry-run] Would create signed tag $tag on medik8s/$r at commit $commit"
+                [[ "$r" != "$repo" ]] || tagged+=("$op:$version")
+                continue
+            fi
+
+            # Build display name for the tag message
+            local tag_display
+            if [[ "$r" == "$repo" ]]; then
+                tag_display="$display"
+            else
+                local -a words
+                IFS='-' read -ra words <<< "$r"
+                tag_display=""
+                for word in "${words[@]}"; do
+                    tag_display+="${word^} "
+                done
+                tag_display="${tag_display% }"
+            fi
+
+            info "[$op $version] Creating signed tag $tag on medik8s/$r at commit $commit"
+            local tmp_upstream="/tmp/${r}-upstream-$$"
+            if ! gh repo clone "medik8s/${r}" "$tmp_upstream" -- --depth 1 2>/dev/null; then
+                rm -rf "$tmp_upstream"
+                die "[$op $version] Failed to clone upstream repo medik8s/${r}"
+            fi
+            if ! git -C "$tmp_upstream" fetch --depth 1 origin "$commit" 2>/dev/null; then
+                rm -rf "$tmp_upstream"
+                die "[$op $version] Commit $commit does not exist on medik8s/${r}. The downstream submodule may point to a commit that was force-pushed or rebased away."
+            fi
+            git -C "$tmp_upstream" tag -s "$tag" "$commit" -m "${tag_display} ${tag}"
+            git -C "$tmp_upstream" push origin "$tag"
+
             rm -rf "$tmp_upstream"
-            die "[$op $version] Failed to clone upstream repo medik8s/${repo}"
-        fi
-        if ! git -C "$tmp_upstream" fetch --depth 1 origin "$commit" 2>/dev/null; then
-            rm -rf "$tmp_upstream"
-            die "[$op $version] Commit $commit does not exist on medik8s/${repo}. The downstream submodule may point to a commit that was force-pushed or rebased away."
-        fi
-        git -C "$tmp_upstream" tag -s "$tag" "$commit" -m "${display} ${tag}"
-        git -C "$tmp_upstream" push origin "$tag"
 
-        rm -rf "$tmp_upstream"
-
-        tagged+=("$op:$version")
-        info "[$op $version] Tag $tag created and pushed"
+            [[ "$r" != "$repo" ]] || tagged+=("$op:$version")
+            info "[$op $version] Tag $tag created and pushed on medik8s/$r"
+        done
     done
 
     log "tag_upstream summary"

--- a/scripts/community-release_test.sh
+++ b/scripts/community-release_test.sh
@@ -80,7 +80,7 @@ run_validate_config() {
 }
 
 run_tag_upstream_with() {
-    local mock_dir="$1" yaml_content="$2"
+    local mock_dir="$1" yaml_content="$2" dry_run="${3:-false}"
     local config_file
     config_file=$(write_yaml_config "$yaml_content")
     (
@@ -88,7 +88,7 @@ run_tag_upstream_with() {
         export PATH="${mock_dir}:${PATH}"
         # shellcheck disable=SC1091
         source "${SCRIPT_DIR}/community-release.sh"
-        DRY_RUN=false
+        DRY_RUN="$dry_run"
         CONFIG_FILE="$config_file"
         parse_yaml_config
         init_operator_metadata
@@ -407,6 +407,170 @@ MOCK
 
     assert_output_contains "downstream tag shown" "$output" "Downstream tag: v5.6.0" || return 1
     assert_output_contains "clone used v5.6.0" "$clone_args" "v5.6.0" || return 1
+}
+
+# ── Dry-run resolves commits from downstream instead of placeholders ──────
+
+test_dryrun_resolves_commits() {
+    local mock_dir
+    mock_dir=$(make_mock_dir)
+
+    cat > "${mock_dir}/gh" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == repos/medik8s/*/git/refs/tags/* ]]; then
+    exit 1  # tag doesn't exist
+fi
+echo "unexpected gh call: $*" >&2; exit 1
+MOCK
+    chmod +x "${mock_dir}/gh"
+
+    cat > "${mock_dir}/git" <<MOCK
+#!/usr/bin/env bash
+case "\$1" in
+    clone)
+        for last; do true; done
+        mkdir -p "\$last"
+        exit 0
+        ;;
+    -C)
+        shift; shift
+        case "\$1" in
+            ls-tree) echo "160000 commit abc123def456 self-node-remediation"; exit 0 ;;
+        esac
+        ;;
+esac
+echo "unexpected git call: \$*" >&2; exit 1
+MOCK
+    chmod +x "${mock_dir}/git"
+
+    local output rc=0
+    output=$(run_tag_upstream_with "$mock_dir" "$SNR_RELEASE" true 2>&1) || rc=$?
+    rm -rf "$mock_dir"
+
+    [[ $rc -eq 0 ]] || { echo "    Expected exit 0, got $rc"; echo "    Output: $output"; return 1; }
+    # Commit was resolved from downstream
+    assert_output_contains "commit resolved" "$output" "Submodule commit for self-node-remediation: abc123def456" || return 1
+    # Dry-run says "would create" with the actual commit
+    assert_output_contains "dry-run with commit" "$output" "Would create signed tag v0.99.0 on medik8s/self-node-remediation at commit abc123def456" || return 1
+    # Should NOT contain old placeholder messages
+    assert_output_not_contains "no clone placeholder" "$output" "Would clone downstream" || return 1
+    assert_output_not_contains "no extract placeholder" "$output" "Would extract submodule" || return 1
+}
+
+# ── NHC companions: all three repos tagged in dry-run ────────────────────
+
+NHC_RELEASE='releases:
+  - operator: NHC
+    version: "0.10.3"
+    previous: "0.10.0"'
+
+test_nhc_companions_dryrun() {
+    local mock_dir
+    mock_dir=$(make_mock_dir)
+
+    cat > "${mock_dir}/gh" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == repos/medik8s/*/git/refs/tags/* ]]; then
+    exit 1  # tag doesn't exist
+fi
+echo "unexpected gh call: $*" >&2; exit 1
+MOCK
+    chmod +x "${mock_dir}/gh"
+
+    cat > "${mock_dir}/git" <<MOCK
+#!/usr/bin/env bash
+case "\$1" in
+    clone)
+        for last; do true; done
+        mkdir -p "\$last"
+        exit 0
+        ;;
+    -C)
+        shift; shift
+        case "\$1" in
+            ls-tree)
+                repo="\$3"
+                case "\$repo" in
+                    node-healthcheck-operator) echo "160000 commit aaa111 node-healthcheck-operator"; exit 0 ;;
+                    node-remediation-console) echo "160000 commit bbb222 node-remediation-console"; exit 0 ;;
+                    must-gather) echo "160000 commit ccc333 must-gather"; exit 0 ;;
+                esac
+                ;;
+        esac
+        ;;
+esac
+echo "unexpected git call: \$*" >&2; exit 1
+MOCK
+    chmod +x "${mock_dir}/git"
+
+    local output rc=0
+    output=$(run_tag_upstream_with "$mock_dir" "$NHC_RELEASE" true 2>&1) || rc=$?
+    rm -rf "$mock_dir"
+
+    [[ $rc -eq 0 ]] || { echo "    Expected exit 0, got $rc"; echo "    Output: $output"; return 1; }
+    # All three commits resolved
+    assert_output_contains "NHC commit" "$output" "Submodule commit for node-healthcheck-operator: aaa111" || return 1
+    assert_output_contains "console commit" "$output" "Submodule commit for node-remediation-console: bbb222" || return 1
+    assert_output_contains "must-gather commit" "$output" "Submodule commit for must-gather: ccc333" || return 1
+    # Dry-run would-create messages for all three
+    assert_output_contains "NHC dry-run" "$output" "Would create signed tag v0.10.3 on medik8s/node-healthcheck-operator at commit aaa111" || return 1
+    assert_output_contains "console dry-run" "$output" "Would create signed tag v0.10.3 on medik8s/node-remediation-console at commit bbb222" || return 1
+    assert_output_contains "must-gather dry-run" "$output" "Would create signed tag v0.10.3 on medik8s/must-gather at commit ccc333" || return 1
+}
+
+# ── NHC companion already tagged → skipped, others still processed ───────
+
+test_nhc_companion_already_tagged() {
+    local mock_dir
+    mock_dir=$(make_mock_dir)
+
+    cat > "${mock_dir}/gh" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == repos/medik8s/*/git/refs/tags/* ]]; then
+    case "$2" in
+        *node-remediation-console*) echo '{"ref":"found"}'; exit 0 ;;  # already tagged
+        *) exit 1 ;;  # needs tagging
+    esac
+fi
+echo "unexpected gh call: $*" >&2; exit 1
+MOCK
+    chmod +x "${mock_dir}/gh"
+
+    cat > "${mock_dir}/git" <<MOCK
+#!/usr/bin/env bash
+case "\$1" in
+    clone)
+        for last; do true; done
+        mkdir -p "\$last"
+        exit 0
+        ;;
+    -C)
+        shift; shift
+        case "\$1" in
+            ls-tree)
+                repo="\$3"
+                case "\$repo" in
+                    node-healthcheck-operator) echo "160000 commit aaa111 node-healthcheck-operator"; exit 0 ;;
+                    must-gather) echo "160000 commit ccc333 must-gather"; exit 0 ;;
+                esac
+                ;;
+        esac
+        ;;
+esac
+echo "unexpected git call: \$*" >&2; exit 1
+MOCK
+    chmod +x "${mock_dir}/git"
+
+    local output rc=0
+    output=$(run_tag_upstream_with "$mock_dir" "$NHC_RELEASE" true 2>&1) || rc=$?
+    rm -rf "$mock_dir"
+
+    [[ $rc -eq 0 ]] || { echo "    Expected exit 0, got $rc"; echo "    Output: $output"; return 1; }
+    # Console plugin skipped
+    assert_output_contains "console skipped" "$output" "already exists on medik8s/node-remediation-console" || return 1
+    # Other two get processed
+    assert_output_contains "NHC tagged" "$output" "Would create signed tag v0.10.3 on medik8s/node-healthcheck-operator" || return 1
+    assert_output_contains "must-gather tagged" "$output" "Would create signed tag v0.10.3 on medik8s/must-gather" || return 1
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1072,6 +1236,9 @@ run_test "partial operator set → only active processed" test_partial_operator_
 run_test "mixed: one exists, one missing → fail on missing" test_mixed_tags_exist_and_missing
 run_test "upstream commit missing → fail with hint" test_upstream_commit_missing
 run_test "downstream version differs → uses downstream tag" test_tag_with_downstream_version
+run_test "dry-run resolves commits from downstream" test_dryrun_resolves_commits
+run_test "NHC companions: all three repos tagged (dry-run)" test_nhc_companions_dryrun
+run_test "NHC companion already tagged → skipped" test_nhc_companion_already_tagged
 
 echo ""
 echo "=== validate_config ==="


### PR DESCRIPTION
#### Why we need this PR

NHC releases depend on two additional images (node-remediation-console and must-gather) that need to be tagged on GitHub from the same downstream repo. Image builds will be triggered by the tags automatically.
Also, the dry-run mode was printing placeholder messages instead of actually resolving commits, making it less useful for verification.

#### Changes made

- Added `OP_COMPANIONS` mapping so NHC releases also tag `node-remediation-console` and `must-gather`
- Companions share the same downstream clone as the main repo (single clone, multiple submodule lookups)
- Companions only participate in the `tag_upstream` step (no build/community/PR steps needed)
- Dry-run now clones downstream and resolves actual submodule commits instead of logging placeholder messages
- Added 3 new tests: dry-run commit resolution, NHC companion tagging, companion skip-when-exists

#### Which issue(s) this PR fixes

N/A

#### Test plan

- [x] All 31 tests pass (`bash scripts/community-release_test.sh`)
- [x] shellcheck passes (only pre-existing SC2004 warnings)
- [x] dry run looks good:

```
$ scripts/community-release.sh --dry-run scripts/release.conf.yaml
==> DRY RUN MODE — no commands will be executed

==> Validating configuration
    Required tools: OK
    GitHub (gh) CLI: OK
==> Configuration summary

    OP     VERSION    PREVIOUS   TARGETS    OCP_VERSION  EXTRA
    ----   -------    --------   -------    -----------  -----
    NHC    0.10.2     0.10.0     k8s okd    4.20         skip_range_lower=0.9.0


==> Step: tag_upstream — creating upstream tags from downstream submodule commits
    [NHC 0.10.2] Checking tag v0.10.2 on medik8s/node-healthcheck-operator
    [NHC 0.10.2] Tag v0.10.2 already exists on medik8s/node-healthcheck-operator — skipping tagging
    [NHC 0.10.2] Checking tag v0.10.2 on medik8s/node-remediation-console
    [NHC 0.10.2] Checking tag v0.10.2 on medik8s/must-gather
    [NHC 0.10.2] Cloning downstream at tag v0.10.2
    [NHC 0.10.2] Submodule commit for node-remediation-console: 219cdd1a0f50f30f92ee266ac45d1186f12411b4
    [NHC 0.10.2] Submodule commit for must-gather: 8234886aa6a7ff914f4aa890f64811548ea47b70
[dry-run] Would create signed tag v0.10.2 on medik8s/node-remediation-console at commit 219cdd1a0f50f30f92ee266ac45d1186f12411b4
[dry-run] Would create signed tag v0.10.2 on medik8s/must-gather at commit 8234886aa6a7ff914f4aa890f64811548ea47b70
==> tag_upstream summary
    Skipped (already existed): NHC:0.10.2
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)