### PR TITLE
Add new team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,10 +8,20 @@ filters:
     - razo7
     - beekhof
     - clobrano
+    - weshayutin
+    - mpryc
+    - jmontleon
+    - abrugaro
+    - eemcmullan
     reviewers:
     - mshitrit
     - slintes
     - razo7
     - beekhof
     - clobrano
+    - weshayutin
+    - mpryc
+    - jmontleon
+    - abrugaro
+    - eemcmullan
 options: {}


### PR DESCRIPTION
## What

Add new team members as approvers and reviewers in the OWNERS file.

## Why

The team has grown and new members need Prow approve/review permissions.

## Changes

- Add weshayutin, mpryc, jmontleon, abrugaro, eemcmullan as approvers and reviewers

## Test plan

- [ ] Verify Prow recognizes the updated OWNERS (CI check passes)
- [ ] Verify new members can `/lgtm` and `/approve`

[RHWA-1332](https://redhat.atlassian.net/browse/RHWA-1332)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership and review assignments for broader maintenance coverage.
  * Added additional designated approvers and reviewers for matching changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->